### PR TITLE
Add SQL execution helper and result table component

### DIFF
--- a/app/backend/approaches/sql_approach.py
+++ b/app/backend/approaches/sql_approach.py
@@ -1,0 +1,50 @@
+from typing import Any
+
+import pyodbc
+from openai import AsyncOpenAI
+
+from approaches.approach import Approach
+
+
+class SqlApproach(Approach):
+    """Simple approach that converts a natural language question into SQL."""
+
+    def __init__(self, *, openai_client: AsyncOpenAI):
+        self.openai_client = openai_client
+
+    async def run(
+        self, messages: list[dict[str, Any]], session_state: Any = None, context: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        if context is None:
+            context = {}
+        q = messages[-1]["content"]
+        sql_prompt = f"Translate to SQL:\n{q}"
+        completion = await self.openai_client.chat.completions.create(
+            model="gpt-35-turbo",
+            messages=[{"role": "user", "content": sql_prompt}],
+        )
+        sql = completion.choices[0].message.content.strip()
+        rows = run_sql(sql)
+        return {
+            "message": {"role": "assistant", "content": f"Ran:\n{sql}"},
+            "context": {"sql": sql, "rows": rows},
+            "session_state": session_state,
+        }
+
+
+def run_sql(sql: str) -> list[dict[str, Any]]:
+    """Execute a SQL query against the claims database."""
+    conn_str = (
+        "Driver={ODBC Driver 18 for SQL Server};"
+        "Server=tcp:text2sql.database.windows.net,1433;"
+        "Database=claims;"
+        "Authentication=ActiveDirectoryInteractive;"
+        "UID=gwhy500@gmail.com;"
+        "Encrypt=yes;TrustServerCertificate=no;"
+    )
+    with pyodbc.connect(conn_str) as conn:
+        cursor = conn.cursor()
+        cursor.execute(sql)
+        columns = [column[0] for column in cursor.description]
+        rows = [dict(zip(columns, row)) for row in cursor.fetchall()]
+    return rows

--- a/app/backend/requirements.in
+++ b/app/backend/requirements.in
@@ -29,5 +29,6 @@ types-beautifulsoup4
 msgraph-sdk
 python-dotenv
 prompty
+pyodbc
 rich
 typing-extensions

--- a/app/backend/requirements.txt
+++ b/app/backend/requirements.txt
@@ -354,6 +354,8 @@ pymupdf==1.26.0
     # via -r requirements.in
 pypdf==4.3.1
     # via -r requirements.in
+pyodbc==5.1.0
+    # via -r requirements.in
 python-dotenv==1.1.1
     # via
     #   -r requirements.in

--- a/app/frontend/src/api/models.ts
+++ b/app/frontend/src/api/models.ts
@@ -59,6 +59,8 @@ export type ResponseContext = {
     data_points: string[];
     followup_questions: string[] | null;
     thoughts: Thoughts[];
+    sql?: string;
+    rows?: any[];
 };
 
 export type ChatAppResponseOrError = {

--- a/app/frontend/src/components/SqlResultTable.tsx
+++ b/app/frontend/src/components/SqlResultTable.tsx
@@ -1,0 +1,21 @@
+import { DetailsList, IColumn } from "@fluentui/react";
+
+interface SqlResultTableProps {
+    rows: Record<string, unknown>[];
+}
+
+export const SqlResultTable = ({ rows }: SqlResultTableProps) => {
+    if (!rows || rows.length === 0) {
+        return null;
+    }
+
+    const columns: IColumn[] = Object.keys(rows[0]).map(key => ({
+        key,
+        name: key,
+        fieldName: key,
+        minWidth: 50,
+        isResizable: true
+    }));
+
+    return <DetailsList items={rows} columns={columns} />;
+};

--- a/app/frontend/src/pages/ask/Ask.module.css
+++ b/app/frontend/src/pages/ask/Ask.module.css
@@ -41,6 +41,14 @@
     padding-right: 1rem;
 }
 
+.sqlQuery {
+    margin-top: 1rem;
+    background-color: #f3f2f1;
+    padding: 0.5rem;
+    font-family: monospace;
+    overflow-x: auto;
+}
+
 .askAnalysisPanel {
     width: 37.5rem;
     margin-left: 1.25rem;

--- a/app/frontend/src/pages/ask/Ask.tsx
+++ b/app/frontend/src/pages/ask/Ask.tsx
@@ -18,6 +18,7 @@ import { useMsal } from "@azure/msal-react";
 import { TokenClaimsDisplay } from "../../components/TokenClaimsDisplay";
 import { LoginContext } from "../../loginContext";
 import { LanguagePicker } from "../../i18n/LanguagePicker";
+import { SqlResultTable } from "../../components/SqlResultTable";
 
 export function Component(): JSX.Element {
     const [isConfigPanelOpen, setIsConfigPanelOpen] = useState(false);
@@ -320,6 +321,10 @@ export function Component(): JSX.Element {
                             showSpeechOutputAzure={showSpeechOutputAzure}
                             showSpeechOutputBrowser={showSpeechOutputBrowser}
                         />
+                        {answer.context?.sql && <pre className={styles.sqlQuery}>{answer.context.sql}</pre>}
+                        {answer.context?.rows && answer.context.rows.length > 0 && (
+                            <SqlResultTable rows={answer.context.rows} />
+                        )}
                     </div>
                 )}
                 {error ? (


### PR DESCRIPTION
## Summary
- add `pyodbc` dependency and new `SqlApproach` with `run_sql` connection to SQL Server
- extend API response context and add `SqlResultTable` component to show query rows
- wire Ask page to display generated SQL and table of results

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*
- `pip install pytest_asyncio` *(fails: Could not connect to proxy)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a22c56118c83258406b5877431db1c